### PR TITLE
Create greatFile.png

### DIFF
--- a/greatFile.png
+++ b/greatFile.png
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:habit/Pages/Groupmanagement.dart';
+
+class HomeBottomAppBar extends StatefulWidget {
+  @override
+  _HomeBottomAppBarState createState() => _HomeBottomAppBarState();
+}
+
+class _HomeBottomAppBarState extends State<HomeBottomAppBar> {
+  @override
+  Widget build(BuildContext context) {
+    return BottomAppBar(
+      child: Container(
+        padding: EdgeInsets.all(20),
+        color: Color(0xFFc9434a),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            Container(
+              width: 125,
+              height: 50,
+              child: RaisedButton.icon(
+                color: Color(0xFFc9434a),
+                onPressed: () {
+                  Navigator.push(context, MaterialPageRoute(builder: (context) => GroupManagement()));
+                },
+                icon: Icon(
+                  Icons.home,
+                  color: Color(0xFFfffad9),
+                ),
+                label: Text(
+                  'Home',
+                  style: TextStyle(
+                    color: Color(0xFFfffad9),
+                  ),
+                ),
+              ),
+            ),
+            Container(
+              width: 125,
+              height: 50,
+              child: RaisedButton.icon(
+                color: Color(0xFFc9434a),
+                onPressed: () {
+                  Navigator.push(context, MaterialPageRoute(builder: (context) => GroupManagement()));
+                },
+                icon: Icon(
+                  Icons.group,
+                  color: Color(0xFFfffad9),
+                ),
+                label: Text(
+                  'Groups',
+                  style: TextStyle(
+                    color: Color(0xFFfffad9),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Most buff effect modifiers can no longer invert the effect of buffs. This fixes a bug where the effect of Shock could be inverted, causing players to be completely immune to damage.

Improved the display of Supportable Skills when hovering over a Support Gem.

Fixed a bug where only the instance owner would receive passive skill points, passive skill refund points, and Ascendancy passive skill points when reaching certain levels in Endless Heist.

Fixed a bug where reducing maximum Leech amount Per Leech below zero would not prevent life leech.

Fixed a bug where legacy Hyrri's Truths, existing prior to 3.16.0, were not granting increased Mana Reservation Efficiency for Precision.